### PR TITLE
fix compatibility with ojs 3.1.1.4

### DIFF
--- a/PorticoExportDom.inc.php
+++ b/PorticoExportDom.inc.php
@@ -192,8 +192,13 @@ class PorticoExportDom extends XMLCustomWriter {
 		$nameNode = self::createElement($doc, 'name');
 		self::appendChild($root, $nameNode);
 
-		self::createChildWithText($doc, $nameNode, 'surname', $author->getLocalizedFamilyName($locale));
-		self::createChildWithText($doc, $nameNode, 'given-names', $author->getLocalizedGivenName($locale));
+		$givenNames = $author->getFirstName();
+		if ($author->getMiddleName()) {
+			$givenNames .= ' ' . $author->getMiddleName();
+		}
+
+		self::createChildWithText($doc, $nameNode, 'surname', $author->getLastName());
+		self::createChildWithText($doc, $nameNode, 'given-names', $givenNames);
 
 		if ($authorIndex == 0) {
 			// See http://pkp.sfu.ca/bugzilla/show_bug.cgi?id=7774

--- a/PorticoExportPlugin.inc.php
+++ b/PorticoExportPlugin.inc.php
@@ -47,6 +47,13 @@ class PorticoExportPlugin extends ImportExportPlugin {
 	}
 
 	/**
+	 * @copydoc Plugin::getTemplatePath($inCore)
+	 */
+	function getTemplatePath($inCore = false) {
+		return parent::getTemplatePath($inCore) . 'templates/';
+	}
+
+	/**
 	 * @copydoc ImportExportPlugin::display()
 	 */
 	public function display($args, $request) {
@@ -91,7 +98,7 @@ class PorticoExportPlugin extends ImportExportPlugin {
 			$templateManager->assign('abbreviation', $value);
 		}
 
-		$templateManager->display($this->getTemplateResource('index.tpl'));
+		$templateManager->display($this->getTemplatePath() . 'index.tpl');
 	}
 
 	/**

--- a/PorticoSettingsForm.inc.php
+++ b/PorticoSettingsForm.inc.php
@@ -36,7 +36,7 @@ class PorticoSettingsForm extends Form {
 		$this->journalId = $journalId;
 		$this->plugin = $plugin;
 
-		parent::__construct($this->plugin->getTemplateResource('settingsForm.tpl'));
+		parent::__construct($this->plugin->getTemplatePath(). 'settingsForm.tpl');
 
 		foreach($this->fields as $name) {
 			$this->addCheck(new FormValidator($this, $name, 'required', 'plugins.importexport.portico.manager.settings.' . $name . 'Required'));


### PR DESCRIPTION
`getLocalizedFamilyName()`, `getLocalizedGivenName()`, and `getTemplateResource()` are not working. This hopefully fixes the issue.